### PR TITLE
Vault Policies by Repo

### DIFF
--- a/sync/modules/user-policy.hcl.j2
+++ b/sync/modules/user-policy.hcl.j2
@@ -22,10 +22,12 @@ path "sys/mounts/*"
 # need to use `data/` because we're on secrets engine v2
 # `data/` will not appear in the actual usage of vault since most clients
 # intelligently add it in. it only appears in the policy
-path "secrets/data/{{ team_name }}-*"
+{% for repo in repos %}
+path "secrets/data/{{ repo }}"
 {
   capabilities = ["create", "read", "update", "delete", "list", "sudo"]
 }
+{% endfor %}
 
 path "secrets/data/{{ team_name }}"
 {

--- a/sync/modules/user-policy.hcl.j2
+++ b/sync/modules/user-policy.hcl.j2
@@ -23,13 +23,13 @@ path "sys/mounts/*"
 # `data/` will not appear in the actual usage of vault since most clients
 # intelligently add it in. it only appears in the policy
 {% for repo in repos %}
+path "secrets/data/{{ repo }}-*"
+{
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+
 path "secrets/data/{{ repo }}"
 {
   capabilities = ["create", "read", "update", "delete", "list", "sudo"]
 }
 {% endfor %}
-
-path "secrets/data/{{ team_name }}"
-{
-  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
-}

--- a/sync/modules/vault.py
+++ b/sync/modules/vault.py
@@ -19,7 +19,8 @@ def sync(teams):
             t = Template(f.read())
             for team in teams["leads"]:
                 base_team_slug = team.slug.replace("-leads", "")
-                pol = t.render(team_name=base_team_slug)
+                repos = [x.name for x in team.get_repos()]
+                pol = t.render(team_name=base_team_slug, repos=repos)
                 client.sys.create_or_update_policy(name=base_team_slug, policy=pol)
                 client.auth.github.map_team(team_name=team.slug, policies=[base_team_slug])
     else:


### PR DESCRIPTION
This PR adjusts our vault policies so that they are dynamically generated from the repos that each team owns.

One thing I'm not sure about is what happens when a team has a repo with the same name as the team, but I'm pretty sure vault will just consider the second definition an update of the first.